### PR TITLE
Python 2.7 compatibility

### DIFF
--- a/dis.py
+++ b/dis.py
@@ -113,7 +113,7 @@ class InputBuffer:
                 
         self.buffer = bytearray(available)
         # Stores which bytes have already been read
-        self.access = bytearray(math.ceil(available / 8))
+        self.access = bytearray(int(math.ceil(available / 8.0)))
         data.readinto(self.buffer)
         
     def was_read(self, o):

--- a/dis.py
+++ b/dis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import getopt
 import io
 import math


### PR DESCRIPTION
Adds an import for (the beginning of) Python 2.7 compatibility. Without this change, Python 2 fails with:

```
TLCS-900 $ python -V
Python 2.7.12
TLCS-900 $ python dis.py 
  File "dis.py", line 77
    clear = lambda: print("\n" * 120)
                        ^
SyntaxError: invalid syntax
```

with this change, `python dis.py` runs successfully and shows the help usage, although attempting to disassemble with Python 2 fails with a different error:

```
TLCS-900 $ python dis.py -i /tmp/in -o /tmp/x
Traceback (most recent call last):
  File "dis.py", line 281, in <module>
    ib = InputBuffer(f, file_len, bounds)
  File "dis.py", line 116, in __init__
    self.access = bytearray(math.ceil(available / 8))
TypeError: 'float' object is not iterable
```

Haven't investigated this second error yet, I went ahead and installed Python 3.5.2 instead and was able to disassemble successfully, but this print_function import is a start towards Python 2 compatibility, hopefully it may be useful. 
